### PR TITLE
remove imports from scripts

### DIFF
--- a/category_number_one/message-sender/message_sender.bpmn
+++ b/category_number_one/message-sender/message_sender.bpmn
@@ -85,7 +85,7 @@
     <bpmn:scriptTask id="set_topic_one" name="Set Topic One" scriptFormat="python">
       <bpmn:incoming>Flow_10conab</bpmn:incoming>
       <bpmn:outgoing>Flow_1ihr88m</bpmn:outgoing>
-      <bpmn:script>import time
+      <bpmn:script>
 timestamp = time.time()
 topic_one_a = f"topic_one_a_conversation_{timestamp}"
 topic_one_b = f"topic_one_b_conversation_{timestamp}"
@@ -112,7 +112,7 @@ del time</bpmn:script>
       <bpmn:scriptTask id="set_topic_two" name="Set Topic Two">
         <bpmn:incoming>Flow_0o5ojq9</bpmn:incoming>
         <bpmn:outgoing>Flow_17gfxad</bpmn:outgoing>
-        <bpmn:script>import time
+        <bpmn:script>
 timestamp = time.time()
 topic_two_a = f"topic_two_a_conversation_{timestamp}"
 topic_two_b = f"topic_two_b_conversation_{timestamp}"

--- a/execute-procure-to-pay/cc-invoice-approval-process/cc-invoice-approval-process-v2.bpmn
+++ b/execute-procure-to-pay/cc-invoice-approval-process/cc-invoice-approval-process-v2.bpmn
@@ -74,7 +74,7 @@
     <bpmn:sequenceFlow id="Flow_1gohkts" name="Yes" sourceRef="Gateway_1lbghql" targetRef="Event_0m3ri6v" />
     <bpmn:sequenceFlow id="Flow_18xvx8w" name="yes" sourceRef="Gateway_1l4tz4i" targetRef="Activity_0fq1nb4" />
     <bpmn:sequenceFlow id="Flow_1m8oeg0" sourceRef="Activity_1ucvkk4" targetRef="Activity_06b32ar" />
-    <bpmn:userTask id="Submit_the_invoice" name="2. Submit the invoice" scriptFormat="python" script="import decimal&#10;&#10;# Check if there are more than two decimal places &#10;d = decimal.Decimal(&#39;56.4325&#39;)&#10;d_cnt = d.as_tuple().exponent&#10;if d_cnt &#60; -2:&#10;	isDecimal = False&#10;else:&#10;	isDecimal = True&#10;&#10;isNameNum = False&#10;for c in contributorName:&#10;	if c.isdigit():&#10;		isNameNum = True&#10;		break">
+    <bpmn:userTask id="Submit_the_invoice" name="2. Submit the invoice" scriptFormat="python" script="# Check if there are more than two decimal places &#10;d = decimal.Decimal(&#39;56.4325&#39;)&#10;d_cnt = d.as_tuple().exponent&#10;if d_cnt &#60; -2:&#10;	isDecimal = False&#10;else:&#10;	isDecimal = True&#10;&#10;isNameNum = False&#10;for c in contributorName:&#10;	if c.isdigit():&#10;		isNameNum = True&#10;		break">
       <bpmn:extensionElements>
         <spiffworkflow:properties>
           <spiffworkflow:property name="formJsonSchemaFilename" value="Submit-the-invoice_JSONSchema.json" />
@@ -292,7 +292,7 @@
       <bpmn:scriptTask id="Activity_Check_Due_Date" name="Check Due Date" scriptFormat="python">
         <bpmn:incoming>Flow_0iiotdb</bpmn:incoming>
         <bpmn:outgoing>Flow_1s4qhn1</bpmn:outgoing>
-        <bpmn:script>from datetime import datetime
+        <bpmn:script>
 
 invoice_date_obj = datetime.strptime(invoice.dueDate, '%Y-%m-%d')
 local_date_time_obj = datetime.strptime(local_date_str, '%Y-%m-%d')
@@ -337,7 +337,7 @@ del c</bpmn:script>
       <bpmn:scriptTask id="Activity_check_invoice_amount" name="Check Invoice Amount" scriptFormat="python">
         <bpmn:incoming>Flow_18qyq02</bpmn:incoming>
         <bpmn:outgoing>Flow_1okg2rg</bpmn:outgoing>
-        <bpmn:script>import decimal
+        <bpmn:script>
 
 # Check if there are more than two decimal places
 invoiceAmount_str = str(invoice.invoiceAmount)

--- a/shared/general/general_local_date_time.bpmn
+++ b/shared/general/general_local_date_time.bpmn
@@ -8,8 +8,7 @@
     <bpmn:scriptTask id="Activity_0h7gas9" name="Get Local Date and Time" scriptFormat="python">
       <bpmn:incoming>Flow_1ipjjs0</bpmn:incoming>
       <bpmn:outgoing>Flow_0agt8ei</bpmn:outgoing>
-      <bpmn:script>from datetime import datetime
-
+      <bpmn:script>
 local_date_time_str = str(datetime.utcnow())
 local_date_time = get_localtime(timestamp=local_date_time_str)
 local_date_str = local_date_time.strftime('%Y-%m-%d')

--- a/shared/local-date-and-time/shared_local_date_time.bpmn
+++ b/shared/local-date-and-time/shared_local_date_time.bpmn
@@ -8,7 +8,7 @@
     <bpmn:scriptTask id="Activity_Get_Local_Date_Time" name="Get Local Date and Time" scriptFormat="python">
       <bpmn:incoming>Flow_1al74ve</bpmn:incoming>
       <bpmn:outgoing>Flow_0xa8fic</bpmn:outgoing>
-      <bpmn:script>from datetime import datetime
+      <bpmn:script>
 
 local_date_time_obj = datetime.utcnow()
 local_date_str = local_date_time_obj.strftime('%Y-%m-%d')

--- a/test/a404/A.4.0.4.bpmn
+++ b/test/a404/A.4.0.4.bpmn
@@ -28,7 +28,7 @@
       <bpmn:scriptTask id="Activity_032nk4u" name="Set Topic One">
         <bpmn:incoming>Flow_17cp9lq</bpmn:incoming>
         <bpmn:outgoing>Flow_1o5couk</bpmn:outgoing>
-        <bpmn:script>import time
+        <bpmn:script>
 timestamp = time.time()
 topic_one_a = f"topic_one_a_conversation_{timestamp}"
 del time</bpmn:script>

--- a/test/tc-41/TC-4.0.bpmn
+++ b/test/tc-41/TC-4.0.bpmn
@@ -26,7 +26,7 @@
     <bpmn:scriptTask id="Activity_0xbi8gj" name="Set Topic One">
       <bpmn:incoming>Flow_0u7lz54</bpmn:incoming>
       <bpmn:outgoing>Flow_0g3hvo9</bpmn:outgoing>
-      <bpmn:script>import time
+      <bpmn:script>
 timestamp = time.time()
 topic_one_a = f"topic_one_a_conversation_{timestamp}"
 del time</bpmn:script>

--- a/test/tc-42/TC-4.1.bpmn
+++ b/test/tc-42/TC-4.1.bpmn
@@ -21,7 +21,7 @@
     <bpmn:scriptTask id="Activity_1unqzlg" name="Set Topic One">
       <bpmn:incoming>Flow_15bgmal</bpmn:incoming>
       <bpmn:outgoing>Flow_1euq8c9</bpmn:outgoing>
-      <bpmn:script>import time
+      <bpmn:script>
 timestamp = time.time()
 topic_one_a = f"topic_one_a_conversation_{timestamp}"
 del time</bpmn:script>

--- a/test/tc-50/TC-4.2.bpmn
+++ b/test/tc-50/TC-4.2.bpmn
@@ -32,7 +32,7 @@
     <bpmn:scriptTask id="Activity_1sf61zm" name="Set Topic">
       <bpmn:incoming>Flow_02trvmu</bpmn:incoming>
       <bpmn:outgoing>Flow_1fciaqh</bpmn:outgoing>
-      <bpmn:script>import time
+      <bpmn:script>
 timestamp = time.time()
 topic_one_a = f"topic_one_a_conversation_{timestamp}"
 del time</bpmn:script>

--- a/test/tc-60/TC-5.2.bpmn
+++ b/test/tc-60/TC-5.2.bpmn
@@ -32,7 +32,7 @@
     <bpmn:scriptTask id="Activity_07kdswo" name="Set Topic">
       <bpmn:incoming>Flow_1kh86v5</bpmn:incoming>
       <bpmn:outgoing>Flow_12hrt0s</bpmn:outgoing>
-      <bpmn:script>import time
+      <bpmn:script>
 timestamp = time.time()
 topic_one_a = f"topic_one_a_conversation_{timestamp}"
 del time</bpmn:script>

--- a/test/tc-61/TC-6.0.bpmn
+++ b/test/tc-61/TC-6.0.bpmn
@@ -27,7 +27,7 @@
     <bpmn:scriptTask id="Activity_1qnybc2" name="Set Topic">
       <bpmn:incoming>Flow_1bk0sdv</bpmn:incoming>
       <bpmn:outgoing>Flow_0tv692t</bpmn:outgoing>
-      <bpmn:script>import time
+      <bpmn:script>
 timestamp = time.time()
 topic_one_a = f"topic_one_a_conversation_{timestamp}"
 del time</bpmn:script>

--- a/test/tc-70/TC-7.0.bpmn
+++ b/test/tc-70/TC-7.0.bpmn
@@ -47,7 +47,7 @@
     <bpmn:scriptTask id="Activity_19g2fkm" name="Set Topic">
       <bpmn:incoming>Flow_1bk0sdv</bpmn:incoming>
       <bpmn:outgoing>Flow_1rkklg1</bpmn:outgoing>
-      <bpmn:script>import time
+      <bpmn:script>
 timestamp = time.time()
 topic_one_a = f"topic_one_a_conversation_{timestamp}"
 topic_one_b = f"topic_one_b_conversation_{timestamp}"


### PR DESCRIPTION
This removes imports from most of the diagrams, as RetsrictedPython disallows `import`.  I added`time`, `datetime.datetime` and `decimal`to the engine globals, so the functions can still be used.  There was a diagram with a more complicated script for importing a csv, which I left unchanged, but will now be broken.