### PR TITLE
Coin gecko call via generic http connector

### DIFF
--- a/misc/jonjon/http/coin-gecko/process_model.json
+++ b/misc/jonjon/http/coin-gecko/process_model.json
@@ -1,0 +1,11 @@
+{
+    "description": "",
+    "display_name": "coin gecko",
+    "display_order": 0,
+    "exception_notification_addresses": [],
+    "fault_or_suspend_on_exception": "fault",
+    "files": [],
+    "metadata_extraction_paths": null,
+    "primary_file_name": "simpleprice.bpmn",
+    "primary_process_id": "Process_dr6y5zi"
+}

--- a/misc/jonjon/http/coin-gecko/simpleprice.bpmn
+++ b/misc/jonjon/http/coin-gecko/simpleprice.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:process id="Process_dr6y5zi" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_116qrm3</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_116qrm3" sourceRef="StartEvent_1" targetRef="Activity_1b0bnuo" />
+    <bpmn:endEvent id="Event_12czlsn">
+      <bpmn:incoming>Flow_0h7q3rh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0h7q3rh" sourceRef="Activity_1b0bnuo" targetRef="Event_12czlsn" />
+    <bpmn:serviceTask id="Activity_1b0bnuo" name="simple price">
+      <bpmn:extensionElements>
+        <spiffworkflow:serviceTaskOperator id="http/GetRequest">
+          <spiffworkflow:parameters>
+            <spiffworkflow:parameter id="auth" type="any" value="None" />
+            <spiffworkflow:parameter id="headers" type="any" value="{&#34;Accept&#34;: &#34;application/json&#34;}" />
+            <spiffworkflow:parameter id="params" type="any" value="{&#34;ids&#34;: &#34;DAI&#34;, &#34;vs_currencies&#34;: &#34;USD,ETH&#34; }" />
+            <spiffworkflow:parameter id="url" type="str" value="&#34;https://api.coingecko.com/api/v3/simple/price&#34;" />
+          </spiffworkflow:parameters>
+        </spiffworkflow:serviceTaskOperator>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_116qrm3</bpmn:incoming>
+      <bpmn:outgoing>Flow_0h7q3rh</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_dr6y5zi">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_12czlsn_di" bpmnElement="Event_12czlsn">
+        <dc:Bounds x="432" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_04czo4m_di" bpmnElement="Activity_1b0bnuo">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_116qrm3_di" bpmnElement="Flow_116qrm3">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0h7q3rh_di" bpmnElement="Flow_0h7q3rh">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="432" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/misc/jonjon/http/process_group.json
+++ b/misc/jonjon/http/process_group.json
@@ -1,0 +1,9 @@
+{
+    "admin": false,
+    "description": "",
+    "display_name": "http",
+    "display_order": 0,
+    "parent_groups": null,
+    "process_groups": [],
+    "process_models": []
+}


### PR DESCRIPTION
Example usage of the http connector to call the coin gecko simple price api to get the price of `DAI` and comparison with `ETH` and `USD`. 